### PR TITLE
Develop task ownership tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - name: Build Funnel (if cache doesn't exist)
+    - name: Build Funnel
       run: make build
 
     - name: Upload Funnel binary as artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
+        cache: false
         go-version-file: go.mod
 
     - name: Build Funnel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        cache: false
         go-version-file: go.mod
 
     - name: Build Funnel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,34 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
-
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: Cache Funnel binary
-      uses: actions/cache@v3
-      with:
-        path: ./funnel
-        key: ${{ runner.os }}-funnel-bin-${{ hashFiles('**/go.sum') }}-${{ github.ref }}
-        restore-keys: |
-          ${{ runner.os }}-funnel-bin-${{ github.ref }}
-          ${{ runner.os }}-funnel-bin-
+        go-version-file: go.mod
 
     - name: Build Funnel (if cache doesn't exist)
-      run: |
-        if [ ! -f ./funnel ]; then
-          make build
-        fi
-    
-    - name: Cache Funnel binary (after build)
-      uses: actions/cache@v3
-      with:
-        path: ./funnel
-        key: ${{ runner.os }}-funnel-bin-${{ hashFiles('**/go.sum') }}-${{ github.ref }}
+      run: make build
 
     - name: Upload Funnel binary as artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,12 +12,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.21
+      - name: Check out code
+        uses: actions/checkout@v4
 
-      - uses: actions/checkout@v3
-      
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -31,7 +33,7 @@ jobs:
               --skip-dirs "funnel-work-dir" \
               -e '.*bundle.go' -e ".*pb.go" -e ".*pb.gw.go" \
               ./...
-      
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -44,12 +46,13 @@ jobs:
   unitTest:
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
-    - name: Check out code
-      uses: actions/checkout@v2
+        go-version-file: go.mod
 
     - name: Unit Tests
       run: make test-verbose
@@ -61,13 +64,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
-
-    - name: Check out code
-      uses: actions/checkout@v2
+        go-version-file: go.mod
 
     - name: Download funnel bin
       uses: actions/download-artifact@v4
@@ -85,17 +88,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
-    - name: Check out code
-      uses: actions/checkout@v2
+        go-version-file: go.mod
 
     - name: Download funnel bin
       uses: actions/download-artifact@v4
       with:
         name: funnel
+
     - name: Badger Test
       run: |
         chmod +x funnel
@@ -105,12 +110,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
-    - name: Check out code
-      uses: actions/checkout@v2
+        go-version-file: go.mod
 
     - name: Download funnel bin
       uses: actions/download-artifact@v4
@@ -126,12 +132,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
-    - name: Check out code
-      uses: actions/checkout@v2
+        go-version-file: go.mod
 
     - name: Download funnel bin
       uses: actions/download-artifact@v4
@@ -144,4 +151,3 @@ jobs:
         make start-generic-s3
         sleep 10
         make test-generic-s3
-          

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,6 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          cache: false
           go-version-file: go.mod
 
       - name: golangci-lint
@@ -53,7 +52,6 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        cache: false
         go-version-file: go.mod
 
     - name: Unit Tests
@@ -72,7 +70,6 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        cache: false
         go-version-file: go.mod
 
     - name: Download funnel bin
@@ -97,7 +94,6 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        cache: false
         go-version-file: go.mod
 
     - name: Download funnel bin
@@ -120,7 +116,6 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        cache: false
         go-version-file: go.mod
 
     - name: Download funnel bin
@@ -143,7 +138,6 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        cache: false
         go-version-file: go.mod
 
     - name: Download funnel bin

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
+          cache: false
           go-version-file: go.mod
 
       - name: golangci-lint
@@ -52,6 +53,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
+        cache: false
         go-version-file: go.mod
 
     - name: Unit Tests
@@ -70,6 +72,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
+        cache: false
         go-version-file: go.mod
 
     - name: Download funnel bin
@@ -94,6 +97,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
+        cache: false
         go-version-file: go.mod
 
     - name: Download funnel bin
@@ -116,6 +120,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
+        cache: false
         go-version-file: go.mod
 
     - name: Download funnel bin
@@ -138,6 +143,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
+        cache: false
         go-version-file: go.mod
 
     - name: Download funnel bin

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build:
 	@touch version/version.go
 	@go build -ldflags '$(VERSION_LDFLAGS)' -buildvcs=false .
 
-# Build an unoptimized version of the code for use during debugging 
+# Build an unoptimized version of the code for use during debugging
 # https://go.dev/doc/gdb
 debug:
 	@go install -gcflags=all="-N -l"
@@ -119,7 +119,7 @@ test-verbose:
 
 start-elasticsearch:
 	@docker rm -f funnel-es-test > /dev/null 2>&1 || echo
-	@docker run -d --name funnel-es-test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:5.6.3 > /dev/null
+	@docker run -d --name funnel-es-test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.io/elastic/elasticsearch:8.17.1 > /dev/null
 
 test-elasticsearch:
 	@go test ./tests/core/ -funnel-config `pwd`/tests/elastic.config.yml
@@ -140,7 +140,7 @@ test-badger:
 
 start-dynamodb:
 	@docker rm -f funnel-dynamodb-test > /dev/null 2>&1 || echo
-	@docker run -d --name funnel-dynamodb-test -p 18000:8000 docker.io/dwmkerr/dynamodb:38 -sharedDb > /dev/null
+	@docker run -d --name funnel-dynamodb-test -p 18000:8000 docker.io/amazon/dynamodb-local > /dev/null
 
 test-dynamodb:
 	@go test ./tests/core/ -funnel-config `pwd`/tests/dynamo.config.yml
@@ -228,7 +228,7 @@ snapshot: release-dep
 docker:
 	docker build -t quay.io/ohsu-comp-bio/funnel:latest ./
 
-# Create a release on Github using GoReleaser 
+# Create a release on Github using GoReleaser
 release:
 	@go get github.com/buchanae/github-release-notes
 	@goreleaser \

--- a/compute/hpc_backend.go
+++ b/compute/hpc_backend.go
@@ -104,11 +104,6 @@ func (b *HPCBackend) Cancel(ctx context.Context, taskID string) error {
 		return err
 	}
 
-	// only cancel tasks in a QUEUED state
-	if task.State != tes.State_QUEUED {
-		return nil
-	}
-
 	backendID := getBackendTaskID(task, b.Name)
 	if backendID == "" {
 		return fmt.Errorf("no %s_id found in metadata for task %s", b.Name, taskID)

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/ohsu-comp-bio/funnel
 
 go 1.23.0
 
-toolchain go1.23.2
-
 require (
 	cloud.google.com/go/datastore v1.20.0
 	cloud.google.com/go/pubsub v1.45.3

--- a/tests/core/task_access_test.go
+++ b/tests/core/task_access_test.go
@@ -1,0 +1,218 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ohsu-comp-bio/funnel/config"
+	"github.com/ohsu-comp-bio/funnel/server"
+	"github.com/ohsu-comp-bio/funnel/tes"
+	"github.com/ohsu-comp-bio/funnel/tests"
+	"google.golang.org/grpc/status"
+)
+
+// These tests verify that access to tasks can be controlled through the
+// configuration parameter: Server.TaskAccess (All, Owner, OwnerOrAdmin).
+
+func TestTaskAccessAll(t *testing.T) {
+	f := initServer(t, server.AccessAll)
+
+	// STEP 1: Create a task for each user
+	f.SwitchUser("User1")
+	task1Id := f.Run(`--sh 'echo 1' --tag scope=TestTaskAccessAll`)
+	f.SwitchUser("User2")
+	task2Id := f.Run(`--sh 'echo 1' --tag scope=TestTaskAccessAll`)
+
+	// STEP 2: Both users should see the tasks (get)
+	checkTaskGet(t, f, "User1", task1Id, true)
+	checkTaskGet(t, f, "User1", task2Id, true)
+
+	checkTaskGet(t, f, "User2", task1Id, true)
+	checkTaskGet(t, f, "User2", task2Id, true)
+
+	// STEP 3: Both users should see the tasks (list)
+	listTasksFilter := &tes.ListTasksRequest{
+		TagKey:   []string{"scope"},
+		TagValue: []string{"TestTaskAccessAll"},
+	}
+
+	checkTaskList(t, f, "User1", listTasksFilter, 2)
+	checkTaskList(t, f, "User2", listTasksFilter, 2)
+
+	// STEP 4: No user should get a permission denied error when cancelling the task
+	checkTaskCancel(t, f, "User1", task1Id, true)
+	checkTaskCancel(t, f, "User1", task2Id, true)
+
+	checkTaskCancel(t, f, "User2", task1Id, true)
+	checkTaskCancel(t, f, "User2", task2Id, true)
+}
+
+func TestTaskAccessOwner(t *testing.T) {
+	f := initServer(t, server.AccessOwner)
+
+	// STEP 1: Create a task for each user
+	f.SwitchUser("User1")
+	task1Id := f.Run(`--sh 'echo 1' --tag scope=TestTaskAccessOwner`)
+	f.SwitchUser("User2")
+	task2Id := f.Run(`--sh 'echo 1' --tag scope=TestTaskAccessOwner`)
+
+	// STEP 2: Both users should see just their own tasks (get)
+	checkTaskGet(t, f, "User1", task1Id, true)
+	checkTaskGet(t, f, "User1", task2Id, false)
+
+	checkTaskGet(t, f, "User2", task1Id, false)
+	checkTaskGet(t, f, "User2", task2Id, true)
+
+	// Even Admin-user cannot see the tasks:
+	checkTaskGet(t, f, "Admin", task1Id, false)
+	checkTaskGet(t, f, "Admin", task2Id, false)
+
+	// STEP 3: Both users should see just their own tasks (list)
+	listTasksFilter := &tes.ListTasksRequest{
+		TagKey:   []string{"scope"},
+		TagValue: []string{"TestTaskAccessOwner"},
+	}
+
+	checkTaskList(t, f, "User1", listTasksFilter, 1)
+	checkTaskList(t, f, "User2", listTasksFilter, 1)
+	checkTaskList(t, f, "Admin", listTasksFilter, 0)
+
+	// STEP 4: Users get a permission denied error when cancelling a task of another user
+	checkTaskCancel(t, f, "User1", task1Id, true)
+	checkTaskCancel(t, f, "User1", task2Id, false)
+
+	checkTaskCancel(t, f, "User2", task1Id, false)
+	checkTaskCancel(t, f, "User2", task2Id, true)
+
+	// Even Admin-user cannot cancel the tasks:
+	checkTaskCancel(t, f, "Admin", task1Id, false)
+	checkTaskCancel(t, f, "Admin", task2Id, false)
+}
+
+func TestTaskAccessOwnerOrAdmin(t *testing.T) {
+	f := initServer(t, server.AccessOwnerOrAdmin)
+
+	// STEP 1: Create a task for each user
+	f.SwitchUser("User1")
+	task1Id := f.Run(`--sh 'echo 1' --tag scope=TestTaskAccessOwnerOrAdmin`)
+	f.SwitchUser("User2")
+	task2Id := f.Run(`--sh 'echo 1' --tag scope=TestTaskAccessOwnerOrAdmin`)
+
+	// STEP 2: Both users should see just their own tasks (get)
+	checkTaskGet(t, f, "User1", task1Id, true)
+	checkTaskGet(t, f, "User1", task2Id, false)
+
+	checkTaskGet(t, f, "User2", task1Id, false)
+	checkTaskGet(t, f, "User2", task2Id, true)
+
+	// Admin-user can see ALL tasks:
+	checkTaskGet(t, f, "Admin", task1Id, true)
+	checkTaskGet(t, f, "Admin", task2Id, true)
+
+	// STEP 3: Both users should see just their tasks (list)
+	listTasksFilter := &tes.ListTasksRequest{
+		TagKey:   []string{"scope"},
+		TagValue: []string{"TestTaskAccessOwnerOrAdmin"},
+	}
+
+	checkTaskList(t, f, "User1", listTasksFilter, 1)
+	checkTaskList(t, f, "User2", listTasksFilter, 1)
+	checkTaskList(t, f, "Admin", listTasksFilter, 2)
+
+	// STEP 4: Users get a permission denied error when cancelling a task of another user
+	checkTaskCancel(t, f, "User1", task1Id, true)
+	checkTaskCancel(t, f, "User1", task2Id, false)
+
+	checkTaskCancel(t, f, "User2", task1Id, false)
+	checkTaskCancel(t, f, "User2", task2Id, true)
+
+	// Admin-user can cancel ALL tasks:
+	checkTaskCancel(t, f, "Admin", task1Id, true)
+	checkTaskCancel(t, f, "Admin", task2Id, true)
+}
+
+func initServer(t *testing.T, taskAccess string) *tests.Funnel {
+	tests.SetLogOutput(log, t)
+
+	c := tests.DefaultConfig()
+	c.Compute = "noop"
+	c.Server.TaskAccess = taskAccess
+
+	c.Server.BasicAuth = []config.BasicCredential{
+		{User: "User1", Password: "user1-password"},
+		{User: "User2", Password: "user2-password"},
+		{User: "Admin", Password: "admin-password", Admin: true},
+	}
+
+	f := tests.NewFunnel(c)
+	f.StartServer()
+	return f
+}
+
+func checkTaskGet(t *testing.T, f *tests.Funnel, username string, taskId string, expectSuccess bool) {
+	f.SwitchUser(username)
+
+	// We are checking each task-view to be sure that view mode does not affect access.
+	for _, view := range tes.View_name {
+		t.Log("GetTask", taskId, "with", view, "view as", username)
+
+		request := &tes.GetTaskRequest{Id: taskId, View: view}
+		response, err := f.RPC.GetTask(context.Background(), request)
+
+		if expectSuccess {
+			if err != nil {
+				t.Fatal("expected GetTask to succeed but got error:", err)
+			} else if response.Id != taskId {
+				t.Fatal("GetTask to returned a different task ID:", response.Id)
+			}
+		} else if err == nil {
+			t.Fatal("expected GetTask to fail (permission denied) but there was no error", response)
+		} else {
+			checkPermissionDenied(t, err)
+		}
+	}
+}
+
+func checkTaskList(t *testing.T, f *tests.Funnel, username string, request *tes.ListTasksRequest, expectedCount int) {
+	f.SwitchUser(username)
+	t.Log("ListTasks as", username)
+
+	response, err := f.RPC.ListTasks(context.Background(), request)
+
+	if err != nil {
+		t.Fatal("ListTasks returned an error:", err)
+	}
+
+	if len(response.Tasks) != expectedCount {
+		t.Fatal("expected", expectedCount, "tasks, got", len(response.Tasks))
+	}
+}
+
+func checkTaskCancel(t *testing.T, f *tests.Funnel, username string, taskId string, expectSuccess bool) {
+	f.SwitchUser(username)
+	t.Log("CancelTask", taskId, "as", username)
+
+	_, err := f.RPC.CancelTask(context.Background(), &tes.CancelTaskRequest{Id: taskId})
+
+	if expectSuccess {
+		if err != nil {
+			t.Fatal("expected CancelTask to fail with the state-change error but got:", err)
+		}
+	} else {
+		checkPermissionDenied(t, err)
+	}
+}
+
+func checkPermissionDenied(t *testing.T, err error) {
+	s := status.Convert(err)
+	if s == nil {
+		t.Fatal("expected grpc status error but received:", err)
+	}
+
+	expectedPrefix := tes.ErrNotPermitted.Error()
+
+	if !strings.HasPrefix(s.Message(), expectedPrefix) {
+		t.Fatal("expected error-prefix [", expectedPrefix, "] but got:", s.Message())
+	}
+}

--- a/tests/funnel_utils.go
+++ b/tests/funnel_utils.go
@@ -147,6 +147,22 @@ func (f *Funnel) PollForServerStart() error {
 	}
 }
 
+// Changes the user who will be making the RPC calls.
+// Panics if that user is not defined in the configuration.
+func (f *Funnel) SwitchUser(username string) {
+	for _, cred := range f.Conf.Server.BasicAuth {
+		if cred.User == username {
+			if f.Conf.RPCClient.User != username {
+				f.Conf.RPCClient.User = cred.User
+				f.Conf.RPCClient.Password = cred.Password
+				f.addRPCClient()
+			}
+			return
+		}
+	}
+	panic("Cannot switch to an undefined user: " + username)
+}
+
 // WaitForDockerDestroy waits for a "destroy" event
 // from docker for the given container ID
 //


### PR DESCRIPTION
This PR is about the **CI pipeline** and **the tests**, following the development of task-ownership and task-access functionalities (https://github.com/ohsu-comp-bio/funnel/pull/1137).

## Changes to Tests

1. **Basic tests** – fixed cases where the tests failed, mostly due to the need for small time-delay to let databases index the data: `tests/core/basic_test.go`.
2. **Slurm test** – `CancelTask` failed due restricting Task status to QUEUED, so it was impossible to cancel: `compute/hpc_backend.go`.
3. Added **new tests for the `Server.TaskAccess`** configuration parameter: `tests/core/task_access_test.go` and `tests/funnel_utils.go`.

## Changes to GitHub Actions

1. Change the order of setting up a Go environment and code checkout:
   1. Setup-Go automatically caches dependencies (depending on the go.sum file), so code checkout needs to happen before Go setup.
   2. Setup-Go now detects the go version from the go.mod file (to avoid different Go versions in different jobs).
3. Removed `toolchain` version from go.mod since the second version unnecessarily increased the cache size.
4. Removed Funnel binary caching (during build) as it lead to bypassing the latest build if go.mod was not modified.

## Kubernetes

This PR does not fix the Kubernetes jobs as the test-setup is more complicated.

I discovered that the job (for a task) never runs because there is a node-selector and taint that prevent assigning the pod to a node ([original commit](https://github.com/ohsu-comp-bio/funnel/commit/571aedec917bf27966ccd4b1b1fe8766b26539c2)). So the setup might include steps:

```
k3d node create funnel-tasks-node -c test-cluster
kubectl label nodes/k3d-funnel-tasks-node-0 role=workflow
kubectl taint nodes/k3d-funnel-tasks-node-0 role=workflow:NoSchedule
```

But after that there was also an issue that it failed to allocate a `PhyicalVolume(Claim)` as the `csi` was configured for AWS: https://github.com/ohsu-comp-bio/funnel/blob/develop/config/kubernetes-pv.yaml#L20. Of course, eventually it gave up: **timed out waiting for external-attacher of s3.csi.aws.com CSI driver to attach volume s3-csi-cui9afid76fc73b4pbmg**.

Since the problem grew bigger than I could handle, I better leave the Kubernetes issue to those who know better than me. 🙂